### PR TITLE
Modified home folder for Vim under Blink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # vim-blink
-Vim plugin manager for blinkshell. 
-Most vim plugin managers depend on the `git` cli, which is not available on blink. This plugin manager uses `curl` to download and install plugins from GitHub instead of `git`. 
+Vim plugin manager for blinkshell.
+Most vim plugin managers depend on the `git` cli, which is not available on blink. This plugin manager uses `curl` to download and install plugins from GitHub instead of `git`.
 
-Add the following to `~/Documents/.vimrc` to install:
+Add the following to `~/.vimrc` to install:
 ```vim
-let data_dir = expand('~/Documents/.vim')
+let data_dir = expand('~/.vim')
 if empty(glob(data_dir . '/autoload/blink.vim'))
     call mkdir(expand(data_dir."/autoload"),"p")
     silent execute '!curl -fLo ' . data_dir . '/autoload/blink.vim --create-dirs  https://raw.githubusercontent.com/rrgeorge/vim-blink/master/blink.vim'
@@ -21,8 +21,8 @@ BlinkInstall 'vim-airline/vim-airline'
 To check all plugins for updates, run `:BlinkUpdate`
 
 ## My vimrc
-This is the `~/Documents/.vimrc` I am using on my devices. You can download it directly if you like, by running:
-`curl -fLo ~/Documents/.vimrc https://raw.githubusercontent.com/rrgeorge/vim-blink/master/vimrc`  
+This is the `~/.vimrc` I am using on my devices. You can download it directly if you like, by running:
+`curl -fLo ~/.vimrc https://raw.githubusercontent.com/rrgeorge/vim-blink/master/vimrc`
 
 The contents:
 ```vim
@@ -32,7 +32,7 @@ set background=dark
 set backspace=2
 syntax on
 
-let data_dir = expand('~/Documents/.vim')
+let data_dir = expand('~/.vim')
 if empty(glob(data_dir . '/autoload/blink.vim'))
     call mkdir(expand(data_dir."/autoload"),"p")
     silent execute '!curl -fLo ' . data_dir . '/autoload/blink.vim --create-dirs  https://raw.githubusercontent.com/rrgeorge/vim-blink/master/blink.vim'

--- a/blink.vim
+++ b/blink.vim
@@ -10,7 +10,7 @@ function! blink#init()
     if exists("g:blink_path")
         let s:blink_path = expand(g:blink_path)
     else
-        let s:blink_path = expand("~/Documents/.vim/pack/blink")
+        let s:blink_path = expand("~/.vim/pack/blink")
     endif
     call mkdir(s:blink_path."/opt","p")
 endfunction

--- a/vimrc
+++ b/vimrc
@@ -4,7 +4,7 @@ set background=dark
 set backspace=2
 syntax on
 
-let data_dir = expand('~/Documents/.vim')
+let data_dir = expand('~/.vim')
 if empty(glob(data_dir . '/autoload/blink.vim'))
     call mkdir(expand(data_dir."/autoload"),"p")
     silent execute '!curl -fLo ' . data_dir . '/autoload/blink.vim --create-dirs  https://raw.githubusercontent.com/rrgeorge/vim-blink/master/blink.vim'


### PR DESCRIPTION
- Used to be on ~/Documents, now it is on ~/.

We discussed over Discord about doing this through a variable. I already noticed there is a g:blink_path that would serve that purpose, so just fixed the "default" path in case nothing is passed.

Verified on Blink side and it is working properly.